### PR TITLE
Fix english scraping bug

### DIFF
--- a/src/main/java/org/zephyrsoft/bibleserverscraper/Scraper.java
+++ b/src/main/java/org/zephyrsoft/bibleserverscraper/Scraper.java
@@ -66,7 +66,7 @@ public class Scraper {
 			try {
 				LOG.debug("fetching {} in {}", bookChapterName, translationAbbreviation);
 				String searchUrl = "https://www.bibleserver.com/text/" + URLEncoder.encode(translationAbbreviation, "UTF-8")
-					+ "/" + URLEncoder.encode(bookChapterName, "UTF-8");
+					+ "/" + URLEncoder.encode(bookChapterName.replaceAll("\\s",""), "UTF-8");
 				Page page = client.getPage(searchUrl);
 
 				if (page.isHtmlPage()) {


### PR DESCRIPTION
When scraping NIV (New International Version), I noticed that the text scraped for *2 Kings* is the text of *1 Kings*, not that of *2 Kings*.

The issue is only in english versions and is because, for "2 Kings 17", the scraper will use the following URL:
`https://www.bibleserver.com/text/NIV/2+Kings18`. However, this url displays the contents of *Kings 17*. We need to remove the whitespace in "2 Kings" to get the correct url `https://www.bibleserver.com/text/NIV/2Kings18`.

This issue was with every book that is named "2 Something" or "3 Something" (except for Mose because they have a distinguished name in english).